### PR TITLE
Fix internal pattern match for JIRA issues 

### DIFF
--- a/src/main/java/com/isroot/stash/plugin/YaccServiceImpl.java
+++ b/src/main/java/com/isroot/stash/plugin/YaccServiceImpl.java
@@ -126,7 +126,7 @@ public class YaccServiceImpl implements YaccService
 			}
 		}
 
-		Pattern singleIssuePattern = Pattern.compile("[a-zA-Z]+-[0-9]+");
+		Pattern singleIssuePattern = Pattern.compile("[A-Z][A-Z_0-9]+-[0-9]+");
 		Matcher matcher = singleIssuePattern.matcher(message);
 		while (matcher.find())
 		{

--- a/src/test/java/ut/com/isroot/stash/plugin/YaccServcieImplTest.java
+++ b/src/test/java/ut/com/isroot/stash/plugin/YaccServcieImplTest.java
@@ -132,7 +132,7 @@ public class YaccServcieImplTest
         when(jiraService.doesJiraApplicationLinkExist()).thenReturn(true);
 
         Changeset changeset = mockChangeset();
-        when(changeset.getMessage()).thenReturn("this commit message has no jira issues");
+        when(changeset.getMessage()).thenReturn("this commit message has no jira issues. abc-123 is not a valid issue because it is lowercase.");
         when(changesetsService.getNewChangesets(any(Repository.class), any(RefChange.class))).thenReturn(Sets.newHashSet(changeset));
 
 		List<String> errors = yaccService.checkRefChange(null, settings, mockRefChange());
@@ -165,7 +165,7 @@ public class YaccServcieImplTest
 		when(jiraService.doesIssueExist(anyString())).thenThrow(CredentialsRequiredException.class);
 
 		Changeset changeset = mockChangeset();
-		when(changeset.getMessage()).thenReturn("ABC-123: this commit has valid issue id");
+		when(changeset.getMessage()).thenReturn("ABC-123: this commit has valid issue id, ABC_D-123: is also a valid issue id");
 		when(changesetsService.getNewChangesets(any(Repository.class), any(RefChange.class))).thenReturn(Sets.newHashSet(changeset));
 
 


### PR DESCRIPTION
as per https://confluence.atlassian.com/display/JIRA/Changing+the+Project+Key+Format

It now matches: PRO_J_ZAA-123, A1_1_B-1, ...

Removed lowercase matching as it is not allowed in JIRA issues

(first time using fork and pull requests)
