### PR TITLE
Include the oauth setup URL in the error message

### DIFF
--- a/src/main/java/com/isroot/stash/plugin/JiraServiceImpl.java
+++ b/src/main/java/com/isroot/stash/plugin/JiraServiceImpl.java
@@ -2,6 +2,7 @@ package com.isroot.stash.plugin;
 
 import com.atlassian.applinks.api.ApplicationLink;
 import com.atlassian.applinks.api.ApplicationLinkRequest;
+import com.atlassian.applinks.api.ApplicationLinkRequestFactory;
 import com.atlassian.applinks.api.ApplicationLinkResponseHandler;
 import com.atlassian.applinks.api.ApplicationLinkService;
 import com.atlassian.applinks.api.CredentialsRequiredException;
@@ -63,14 +64,16 @@ public class JiraServiceImpl implements JiraService
     {
         checkNotNull(issueKey, "issueKey is null");
 
-		ApplicationLinkRequest req = getJiraApplicationLink().createAuthenticatedRequestFactory().createRequest(Request.MethodType.GET, "/rest/api/2/issue/"+issueKey.getFullyQualifiedIssueKey());
+		final ApplicationLinkRequestFactory fac = getJiraApplicationLink().createAuthenticatedRequestFactory();
+
+		ApplicationLinkRequest req = fac.createRequest(Request.MethodType.GET, "/rest/api/2/issue/"+issueKey.getFullyQualifiedIssueKey());
 
 		return req.execute(new ApplicationLinkResponseHandler<Boolean>()
 		{
 			@Override
 			public Boolean credentialsRequired(Response response) throws ResponseException
 			{
-				return false;
+				throw new ResponseException(new CredentialsRequiredException(fac, "Token is invalid"));
 			}
 
 			@Override

--- a/src/main/java/com/isroot/stash/plugin/YaccServiceImpl.java
+++ b/src/main/java/com/isroot/stash/plugin/YaccServiceImpl.java
@@ -167,6 +167,7 @@ public class YaccServiceImpl implements YaccService
 		{
 			log.error("communication error while validating issues", e);
 			errors.add(String.format("Unable to validate JIRA issue because there was an authentication failure when communicating with JIRA."));
+			errors.add(String.format("To authenticate, visit %s in a web browser.", e.getAuthorisationURI().toASCIIString()));
 			return errors;
 		}
 		catch(ResponseException e)
@@ -216,6 +217,7 @@ public class YaccServiceImpl implements YaccService
 		catch(CredentialsRequiredException e)
 		{
 			errors.add(String.format("%s: Unable to validate JIRA issue because there was an authentication failure when communicating with JIRA.", issueKey.getFullyQualifiedIssueKey()));
+			errors.add(String.format("To authenticate, visit %s in a web browser.", e.getAuthorisationURI().toASCIIString()));
 		}
 		catch(ResponseException e)
 		{

--- a/src/main/java/com/isroot/stash/plugin/YaccServiceImpl.java
+++ b/src/main/java/com/isroot/stash/plugin/YaccServiceImpl.java
@@ -221,8 +221,14 @@ public class YaccServiceImpl implements YaccService
 		}
 		catch(ResponseException e)
 		{
-			log.error("unexpected exception while trying to validate JIRA issue", e);
-			errors.add(String.format("%s: Unable to validate JIRA issue due to an unexpected exception. Please see stack trace in logs.", issueKey.getFullyQualifiedIssueKey()));
+			if (e.getCause() instanceof CredentialsRequiredException) {
+				CredentialsRequiredException cred = (CredentialsRequiredException)e.getCause();
+				errors.add(String.format("%s: Unable to validate JIRA issue because there was an authentication failure when communicating with JIRA.", issueKey.getFullyQualifiedIssueKey()));
+				errors.add(String.format("To authenticate, visit %s in a web browser.", cred.getAuthorisationURI().toASCIIString()));
+			} else {
+				log.error("unexpected exception while trying to validate JIRA issue", e);
+				errors.add(String.format("%s: Unable to validate JIRA issue due to an unexpected exception. Please see stack trace in logs.", issueKey.getFullyQualifiedIssueKey()));
+			}
 		}
 
 		return errors;

--- a/src/test/java/ut/com/isroot/stash/plugin/YaccServiceImplTest.java
+++ b/src/test/java/ut/com/isroot/stash/plugin/YaccServiceImplTest.java
@@ -1,6 +1,7 @@
 package ut.com.isroot.stash.plugin;
 
 import com.atlassian.applinks.api.CredentialsRequiredException;
+import com.atlassian.sal.api.net.ResponseException;
 import com.atlassian.stash.repository.RefChange;
 import com.atlassian.stash.repository.RefChangeType;
 import com.atlassian.stash.repository.Repository;
@@ -40,6 +41,7 @@ public class YaccServiceImplTest
     @Mock private StashAuthenticationContext stashAuthenticationContext;
     @Mock private ChangesetsService changesetsService;
     @Mock private JiraService jiraService;
+    @Mock private ResponseException responseException;
     @Mock private CredentialsRequiredException credRequired;
     @Mock private Settings settings;
     @Mock private StashUser stashUser;
@@ -228,11 +230,31 @@ public class YaccServiceImplTest
     }
 
     @Test
-    public void testCheckRefChange_requireJiraIssue_errorReturnedIfJiraAuthenticationFails() throws Exception
+    public void testCheckRefChange_requireJiraIssue_errorReturnedIfNoJiraAuth() throws Exception
     {
         when(settings.getBoolean("requireJiraIssue", false)).thenReturn(true);
         when(jiraService.doesJiraApplicationLinkExist()).thenReturn(true);
         when(jiraService.doesIssueExist(any(IssueKey.class))).thenThrow(credRequired);
+        when(credRequired.getAuthorisationURI()).thenReturn(new URI("http://localhost/link"));
+
+        YaccChangeset changeset = mockChangeset();
+        when(changeset.getMessage()).thenReturn("ABC-123: this commit has valid issue id");
+        when(changesetsService.getNewChangesets(any(Repository.class), any(RefChange.class))).thenReturn(Sets.newHashSet(changeset));
+
+
+        List<String> errors = yaccService.checkRefChange(null, settings, mockRefChange());
+        assertThat(errors).contains("refs/heads/master: deadbeef: ABC-123: Unable to validate JIRA issue because there was an authentication failure when communicating with JIRA.");
+        assertThat(errors).contains("refs/heads/master: deadbeef: To authenticate, visit http://localhost/link in a web browser.");
+        verify(jiraService).doesIssueExist(new IssueKey("ABC-123"));
+    }
+
+    @Test
+    public void testCheckRefChange_requireJiraIssue_errorReturnedIfJiraAuthenticationFails() throws Exception
+    {
+        when(settings.getBoolean("requireJiraIssue", false)).thenReturn(true);
+        when(jiraService.doesJiraApplicationLinkExist()).thenReturn(true);
+        when(jiraService.doesIssueExist(any(IssueKey.class))).thenThrow(responseException);
+        when(responseException.getCause()).thenReturn(credRequired);
         when(credRequired.getAuthorisationURI()).thenReturn(new URI("http://localhost/link"));
 
         YaccChangeset changeset = mockChangeset();


### PR DESCRIPTION
When the JIRA issue validation fails because there is no oauth token,
give the user the URL to use to create the trust relationship.

This is a much better user experience than telling the user to go and
find a commit in the web UI with a JIRA issue and click on it.
