### PR TITLE
Validate tag committer/messages

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,11 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>com.atlassian.stash</groupId>
+            <artifactId>stash-scm-git-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>com.atlassian.applinks</groupId>
             <artifactId>applinks-api</artifactId>
             <scope>provided</scope>

--- a/src/main/java/com/isroot/stash/plugin/ChangesetsServiceImpl.java
+++ b/src/main/java/com/isroot/stash/plugin/ChangesetsServiceImpl.java
@@ -4,21 +4,24 @@ import com.atlassian.stash.commit.CommitService;
 import com.atlassian.stash.content.Changeset;
 import com.atlassian.stash.content.ChangesetsBetweenRequest;
 import com.atlassian.stash.repository.RefChange;
+import com.atlassian.stash.repository.RefChangeType;
 import com.atlassian.stash.repository.Repository;
+import com.atlassian.stash.scm.git.GitRefPattern;
 import com.atlassian.stash.server.ApplicationPropertiesService;
 import com.atlassian.stash.util.Page;
 import com.atlassian.stash.util.PageRequest;
 import com.atlassian.stash.util.PageRequestImpl;
 import com.google.common.collect.Sets;
-import org.eclipse.jgit.lib.ObjectId;
-import org.eclipse.jgit.lib.PersonIdent;
-import org.eclipse.jgit.revwalk.RevCommit;
-import org.eclipse.jgit.revwalk.RevWalk;
-import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
-
 import java.io.File;
 import java.io.IOException;
 import java.util.Set;
+import org.eclipse.jgit.lib.ObjectId;
+import org.eclipse.jgit.lib.PersonIdent;
+import org.eclipse.jgit.revwalk.RevCommit;
+import org.eclipse.jgit.revwalk.RevObject;
+import org.eclipse.jgit.revwalk.RevTag;
+import org.eclipse.jgit.revwalk.RevWalk;
+import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
 
 /**
  * @author Sean Ford
@@ -45,32 +48,72 @@ public class ChangesetsServiceImpl implements ChangesetsService
         {
             org.eclipse.jgit.lib.Repository jGitRepo = getJGitRepo(repository);
 
-            ChangesetsBetweenRequest request = new ChangesetsBetweenRequest.Builder(repository)
-                    .exclude(getBranches(repository))
-                    .include(refChange.getToHash())
-                    .build();
+            RevWalk walk = new RevWalk(jGitRepo);
 
-            Page<Changeset> page = commitService.getChangesetsBetween(request, new PageRequestImpl(0, PageRequest.MAX_PAGE_LIMIT));
-
+            /* Tags are different to regular commits - they're just pointers.
+             * The only relevent commitId is the destination one (and even then only for
+             * ADD and UPDATE).
+             * We need to work out whether or not the tag is lightweight (in which case
+             * its commitid is an already-existing commit that we don't want to check - 
+             * it may have been made by someone else) or annotated (in which case we do
+             * care.
+             *
+             * Stash's API to work out the tag type doesn't work (see STASH-4993)
+             * and since we're using JGit anyway, just use it for the whole lot.
+             */
             Set<YaccChangeset> changesets = Sets.newHashSet();
-            for (Changeset changeset : page.getValues())
-            {
-                final RevWalk walk = new RevWalk(jGitRepo);
-                final RevCommit commit = walk.parseCommit(ObjectId.fromString(changeset.getId()));
 
-                /* Note that we use committer, instead of author -- for most commits, these will be identical. Where
-                 * this differs is if a patch *author* submits a patch (eg, consider an external contribution), and
-                 * the *committer* actually applies the patch.
-                 *
-                 * By validating the committer here, we can allow surrogate commits on behalf of patch submitters,
-                 * while still ensuring that the authenticated user is either the author *or* the committer.
-                 */
-                final PersonIdent ident = commit.getCommitterIdent();
-                final String message = commit.getFullMessage();
+            if (refChange.getRefId().startsWith(GitRefPattern.TAGS.getPath()))
+            {
+                if (refChange.getType() == RefChangeType.DELETE)
+                {
+                    // Deletes don't leave anything to check
+                    return changesets;
+                }
+
+                RevObject obj = walk.parseAny(ObjectId.fromString(refChange.getToHash()));
+                if (!(obj instanceof RevTag))
+                {
+                    // Just a lightweight tag - nothing to check
+                    return changesets;
+                }
+
+                RevTag tag = (RevTag) obj;
+
+                PersonIdent ident = tag.getTaggerIdent();
+                final String message = tag.getFullMessage();
                 final YaccPerson committer = new YaccPerson(ident.getName(), ident.getEmailAddress());
-                final YaccChangeset yaccChangeset = new YaccChangeset(changeset.getId(), committer, message, commit.getParentCount());
+                final YaccChangeset yaccChangeset = new YaccChangeset(refChange.getToHash(), committer, message, 1);
 
                 changesets.add(yaccChangeset);
+            }
+            else
+            {
+                final ChangesetsBetweenRequest request = new ChangesetsBetweenRequest.Builder(repository)
+                        .exclude(getBranches(repository))
+                        .include(refChange.getToHash())
+                        .build();
+
+                Page<Changeset> page = commitService.getChangesetsBetween(request, new PageRequestImpl(0, PageRequest.MAX_PAGE_LIMIT));
+
+                for (Changeset changeset : page.getValues())
+                {
+                    final RevCommit commit = walk.parseCommit(ObjectId.fromString(changeset.getId()));
+
+                    /* Note that we use committer, instead of author -- for most commits, these will be identical. Where
+                     * this differs is if a patch *author* submits a patch (eg, consider an external contribution), and
+                     * the *committer* actually applies the patch.
+                     *
+                     * By validating the committer here, we can allow surrogate commits on behalf of patch submitters,
+                     * while still ensuring that the authenticated user is either the author *or* the committer.
+                     */
+                    final PersonIdent ident = commit.getCommitterIdent();
+                    final String message = commit.getFullMessage();
+                    final YaccPerson committer = new YaccPerson(ident.getName(), ident.getEmailAddress());
+                    final YaccChangeset yaccChangeset = new YaccChangeset(changeset.getId(), committer, message, commit.getParentCount());
+
+                    changesets.add(yaccChangeset);
+                }
             }
 
             return changesets;


### PR DESCRIPTION
Tags are a bit different to regular commits. For lightweight tags, the commit id is the same as the commit that they point to, and there is no content to validate.

For annotated tags however, the new ref id is a special 'tag' object, and Stash's APIs won't find the difference, since its not a 'change' to appear in a Changeset. (If the tag is being moved, the fromHash and the newHash don't have any connection to each other, which also confuses things). See STASH-4993.

Since this code is already using jgit, just use that to parse the tagger.

While in this code, I changed the use of the commit service to use a paged iterator so that commits beyond the most recent 100 are validated. (While MAX_PAGE_LIMIT is > 100k, that's just a request - there's a page.max.commits property that limits it to 100).

There aren't any test cases for this method, so I manually tested it with tags (not the JIRA integration though). Try 'git tag -a -m test test; git push --tags' with a username that doesn't match.

(the pom.xml changes made things easier to develop)
