### PR TITLE
Handle the user's email address being null

### DIFF
--- a/src/main/java/com/isroot/stash/plugin/YaccPerson.java
+++ b/src/main/java/com/isroot/stash/plugin/YaccPerson.java
@@ -1,5 +1,7 @@
 package com.isroot.stash.plugin;
 
+import javax.annotation.Nonnull;
+
 /**
  * A git person identity.
  */
@@ -10,7 +12,7 @@ public class YaccPerson {
      * @param name The name of the person.
      * @param emailAddress The e-mail address of the person.
      */
-    public YaccPerson(String name, String emailAddress) {
+    public YaccPerson(@Nonnull String name, @Nonnull String emailAddress) {
         this.name = name;
         this.emailAddress = emailAddress;
     }
@@ -20,6 +22,7 @@ public class YaccPerson {
      *
      * @return Name of person.
      */
+    @Nonnull
     public String getName() {
         return name;
     }
@@ -29,6 +32,7 @@ public class YaccPerson {
      *
      * @return E-mail of person.
      */
+    @Nonnull
     public String getEmailAddress() {
         return emailAddress;
     }


### PR DESCRIPTION
Service users (ie ssh access keys) don't have a valid email, so this breaks
the email validation.

Just skip all name checks for service users - access key users are
automated systems, and the 'name' is generally meaningless too (its the
SSH key comment)

Fixes #21
