### PR TITLE
[26] Allow to exclude service users from commit checks

### DIFF
--- a/src/main/java/com/isroot/stash/plugin/YaccServiceImpl.java
+++ b/src/main/java/com/isroot/stash/plugin/YaccServiceImpl.java
@@ -110,6 +110,11 @@ public class YaccServiceImpl implements YaccService
             return true;
         }
 
+        // Exclude by Service User setting
+        StashUser stashUser = stashAuthenticationContext.getCurrentUser();
+        if (settings.getBoolean("excludeServiceUserCommits") && stashUser.getType() == UserType.SERVICE)
+            return true;
+
         // Exclude by Regex setting
         String excludeRegex = settings.getString("excludeByRegex");
 

--- a/src/main/resources/static/simple.soy
+++ b/src/main/resources/static/simple.soy
@@ -83,6 +83,16 @@
 		{param value: $config['excludeByRegex'] /}
 		{param descriptionText: 'Exclude commits if commit message matches this regex.' /}
 		{param errorTexts: $errors ? $errors['excludeByRegex'] : null /}
-	{/call}
+   {/call}
+
+   {call aui.form.checkboxField}
+    {param legendContent: 'Exclude Service User Commits' /}
+      {param fields: [[
+        'id' : 'excludeServiceUserCommits',
+        'labelText': stash_i18n('stash.web.stash.enable-ci-radio.button.label', 'Enabled'),
+        'isChecked' : $config['excludeServiceUserCommits']
+      ]] /}
+    {param descriptionText: 'Exclude commits from service users with access keys (e.g. CI Server) from commit requirements.' /}
+  {/call}
 
 {/template}

--- a/src/test/java/ut/com/isroot/stash/plugin/YaccServiceImplTest.java
+++ b/src/test/java/ut/com/isroot/stash/plugin/YaccServiceImplTest.java
@@ -434,6 +434,23 @@ public class YaccServiceImplTest
         verifyNoMoreInteractions(jiraService);
     }
 
+    @Test
+    public void testCheckRefChange_excludeServiceUserCommitsWithInvalidCommitMessage()
+    {
+        when(settings.getString("commitMessageRegex")).thenReturn("[a-z ]+");
+        when(settings.getBoolean("excludeServiceUserCommits")).thenReturn(true);
+
+        when(stashUser.getType()).thenReturn(UserType.SERVICE);
+
+        YaccChangeset changeset = mockChangeset();
+        when(changeset.getMessage()).thenReturn("123 does not match regex because it contains numbers");
+        when(changesetsService.getNewChangesets(any(Repository.class), any(RefChange.class))).thenReturn(Sets.newHashSet(changeset));
+
+        List<String> errors = yaccService.checkRefChange(null, settings, mockRefChange());
+        assertThat(errors).isEmpty();
+        verify(settings).getBoolean("excludeServiceUserCommits");
+    }
+
     private YaccChangeset mockChangeset()
     {
         YaccChangeset changeset = mock(YaccChangeset.class, RETURNS_DEEP_STUBS);


### PR DESCRIPTION
This is an implementation for https://github.com/sford/yet-another-commit-checker/issues/26.

We use this to allow Jenkins to commit without a proper JIRA e.g. for automatic code formatting done by Jenkins.
