### PR TITLE
Trim Git "CRUD" from Author Name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,11 @@
     </dependencyManagement>
     <dependencies>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.0</version>
+        </dependency>
+        <dependency>
             <groupId>com.atlassian.stash</groupId>
             <artifactId>stash-api</artifactId>
             <scope>provided</scope>

--- a/src/main/java/com/isroot/stash/plugin/YaccPerson.java
+++ b/src/main/java/com/isroot/stash/plugin/YaccPerson.java
@@ -1,5 +1,7 @@
 package com.isroot.stash.plugin;
 
+import org.apache.commons.lang.StringUtils;
+
 import javax.annotation.Nonnull;
 
 /**
@@ -24,7 +26,7 @@ public class YaccPerson {
      */
     @Nonnull
     public String getName() {
-        return name;
+        return removeGitCRUD(name);
     }
 
     /**
@@ -43,4 +45,9 @@ public class YaccPerson {
     /** E-mail address of person */
     private final String emailAddress;
 
+
+    /** Removes "Illegal Terminating" characters from Git UserNames.  See the GIT Function  static int crud(unsigned char c)*/
+    private String removeGitCRUD(@Nonnull String name) {
+        return StringUtils.stripEnd(name, ".,:<>\"\\\'");
+    }
 }

--- a/src/test/java/ut/com/isroot/stash/plugin/YaccServiceImplTest.java
+++ b/src/test/java/ut/com/isroot/stash/plugin/YaccServiceImplTest.java
@@ -16,6 +16,7 @@ import com.isroot.stash.plugin.JiraService;
 import com.isroot.stash.plugin.YaccChangeset;
 import com.isroot.stash.plugin.YaccService;
 import com.isroot.stash.plugin.YaccServiceImpl;
+import org.apache.commons.lang.StringUtils;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -382,7 +383,33 @@ public class YaccServiceImplTest
         verify(settings).getBoolean("excludeMergeCommits", false);
     }
 
+
     @Test
+    public void testCheckRefChange_tag_checksUserName_withCrud()
+    {
+
+        when(settings.getBoolean("requireMatchingAuthorName", false)).thenReturn(true);
+        when(settings.getBoolean("requireMatchingAuthorEmail", false)).thenReturn(true);
+        when(stashUser.getType()).thenReturn(UserType.NORMAL);
+        String name = "Smith, John P.";
+        when(stashUser.getDisplayName()).thenReturn(org.apache.commons.lang.StringUtils.stripEnd(name, ".,:<>\"\\\'"));
+        when(stashUser.getEmailAddress()).thenReturn("jsmith@example.com");
+
+        YaccChangeset changeset = mockChangeset_withCrud();
+        when(changeset.getCommitter().getName()).thenReturn("Smith, John P");
+        when(changeset.getCommitter().getEmailAddress()).thenReturn("jsmith@example.com");
+        when(changesetsService.getNewChangesets(any(Repository.class), any(RefChange.class))).thenReturn(Sets.newHashSet(changeset));
+
+        List<String> errors = yaccService.checkRefChange(null, settings, mockTagChange());
+        assertThat(errors).isEmpty();
+    }
+
+    @Test
+    public void checkCrudRemover() {
+        assert(StringUtils.stripEnd("Hello,.", ".,").equals("Hello"));
+    }
+
+        @Test
     public void testCheckRefChange_tag_checksUser()
     {
         when(settings.getBoolean("requireMatchingAuthorName", false)).thenReturn(true);
@@ -433,6 +460,8 @@ public class YaccServiceImplTest
         verifyNoMoreInteractions(jiraService);
     }
 
+
+
     @Test
     public void testCheckRefChange_excludeServiceUserCommitsWithInvalidCommitMessage()
     {
@@ -449,6 +478,18 @@ public class YaccServiceImplTest
         assertThat(errors).isEmpty();
         verify(settings).getBoolean("excludeServiceUserCommits", false);
     }
+
+
+    private YaccChangeset mockChangeset_withCrud()
+    {
+        YaccChangeset changeset = mock(YaccChangeset.class, RETURNS_DEEP_STUBS);
+        when(changeset.getCommitter().getName()).thenReturn("Smith, John C");
+        when(changeset.getCommitter().getEmailAddress()).thenReturn("jsmith@example.com");
+        when(changeset.getId()).thenReturn("deadbeef");
+        when(changeset.getParentCount()).thenReturn(1);
+        return changeset;
+    }
+
 
     private YaccChangeset mockChangeset()
     {


### PR DESCRIPTION
I used ApacheStringUtils to remove all "CRUD" characters off the author name.  This came from my issue and the StackOverflow post http://stackoverflow.com/questions/26159274/is-it-possible-to-have-a-trailing-period-in-user-name-in-git/26219423#26219423
